### PR TITLE
Center DatePicker on iPad

### DIFF
--- a/ModalPickerSample/Info.plist
+++ b/ModalPickerSample/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -17,6 +17,7 @@
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
+		<integer>2</integer>
 	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>

--- a/SharpMobileCode.ModalPicker/ModalPickerViewController.cs
+++ b/SharpMobileCode.ModalPicker/ModalPickerViewController.cs
@@ -180,7 +180,9 @@ namespace SharpMobileCode.ModalPicker
             switch(_pickerType)
             {
                 case ModalPickerType.Date:
-                    DatePicker.Frame = new RectangleF(DatePicker.Frame.X, _headerBarHeight, DatePicker.Frame.Width,
+                    var pickerWidth = DatePicker.Frame.Width;
+                    var xOffset = (width - pickerWidth) / 2.0f;
+                    DatePicker.Frame = new RectangleF(xOffset, _headerBarHeight, pickerWidth,
                                                       DatePicker.Frame.Height);
                     break;
                 case ModalPickerType.Custom:


### PR DESCRIPTION
Center the DatePicker in the available width on the iPad.  "Custom" pickers already take up the full width so no change is necessary there.

### Before
![before](https://cloud.githubusercontent.com/assets/90451/4485162/191f7c14-49c6-11e4-95b5-d5c1af199886.png)

### After
![after](https://cloud.githubusercontent.com/assets/90451/4485166/2081a608-49c6-11e4-9684-01b8284b55f2.png)

