### PR TITLE
DatePicker center and fill width on iPad

### DIFF
--- a/SharpMobileCode.ModalPicker/ModalPickerViewController.cs
+++ b/SharpMobileCode.ModalPicker/ModalPickerViewController.cs
@@ -180,7 +180,7 @@ namespace SharpMobileCode.ModalPicker
             switch(_pickerType)
             {
                 case ModalPickerType.Date:
-                    DatePicker.Frame = new RectangleF(DatePicker.Frame.X, _headerBarHeight, DatePicker.Frame.Width,
+                    DatePicker.Frame = new RectangleF(DatePicker.Frame.X, _headerBarHeight, _internalView.Frame.Width,
                                                       DatePicker.Frame.Height);
                     break;
                 case ModalPickerType.Custom:


### PR DESCRIPTION
On iPad the DatePicker was placed to the left side of the screen. This way it's centered and filling the entire width of the frame it's in. Also, you should probably make the sample an Universal App

Before:

![ios simulator screen shot 8 nov 2014 11 01 16](https://cloud.githubusercontent.com/assets/4228546/4963797/9bb545d4-672e-11e4-833d-d67e3633685d.png)

After:

![ios simulator screen shot 8 nov 2014 11 02 25](https://cloud.githubusercontent.com/assets/4228546/4963798/9bbbf8b6-672e-11e4-87ad-53a17cb5c308.png)