### PR TITLE
Individual text for done button

### DIFF
--- a/ModalPickerSample/ModalPickerSampleViewController.cs
+++ b/ModalPickerSample/ModalPickerSampleViewController.cs
@@ -63,8 +63,7 @@ namespace ModalPickerSample
             {
                 HeaderBackgroundColor = UIColor.Red,
                 HeaderTextColor = UIColor.White,
-                TransitioningDelegate = new ModalPickerTransitionDelegate(),
-                ModalPresentationStyle = UIModalPresentationStyle.Custom
+                DoneButtonText = "Save"
             };
 
             modalPicker.DatePicker.Mode = UIDatePickerMode.Date;
@@ -95,9 +94,7 @@ namespace ModalPickerSample
             var modalPicker = new ModalPickerViewController(ModalPickerType.Custom, "Select A Date", this)
             {
                 HeaderBackgroundColor = UIColor.Blue,
-                HeaderTextColor = UIColor.White,
-                TransitioningDelegate = new ModalPickerTransitionDelegate(),
-                ModalPresentationStyle = UIModalPresentationStyle.Custom
+                HeaderTextColor = UIColor.White
             };
 
             //Create the model for the Picker View

--- a/SharpMobileCode.ModalPicker/ModalPickerViewController.cs
+++ b/SharpMobileCode.ModalPicker/ModalPickerViewController.cs
@@ -33,6 +33,7 @@ namespace SharpMobileCode.ModalPicker
         public UIColor HeaderBackgroundColor { get; set; }
         public UIColor HeaderTextColor { get; set; }
         public string HeaderText { get; set; }
+        public string DoneButtonText { get; set; }
 
         public UIDatePicker DatePicker { get; set; }
         public UIPickerView PickerView { get; set; }
@@ -70,8 +71,12 @@ namespace SharpMobileCode.ModalPicker
             HeaderBackgroundColor = UIColor.White;
             HeaderTextColor = UIColor.Black;
             HeaderText = headerText;
+            DoneButtonText = "Done"; // Default value
             PickerType = pickerType;
             _parent = parent;
+
+            TransitioningDelegate = new ModalPickerTransitionDelegate();
+            ModalPresentationStyle = UIModalPresentationStyle.Custom;
         }
 
         public override void ViewDidLoad()
@@ -102,7 +107,7 @@ namespace SharpMobileCode.ModalPicker
             _doneButton = UIButton.FromType(UIButtonType.System);
             _doneButton.SetTitleColor(HeaderTextColor, UIControlState.Normal);
             _doneButton.BackgroundColor = UIColor.Clear;
-            _doneButton.SetTitle("Done", UIControlState.Normal);
+            _doneButton.SetTitle(DoneButtonText, UIControlState.Normal);
             _doneButton.TouchUpInside += DoneButtonTapped;
 
             switch(PickerType)


### PR DESCRIPTION
- Make it possible to individualize done button caption
 - Default value is still “Done”, existing usages do not change
- Initialize both TransitioningDelegate and ModalPresentationStyle
within the constructor
 - No need of initializing them each time externally. But can be
overridden in any case.